### PR TITLE
added marketplace docs

### DIFF
--- a/docs/documentation/capabilities/agent.mdx
+++ b/docs/documentation/capabilities/agent.mdx
@@ -33,6 +33,7 @@ The Agent Completions endpoint (`/v1/agent/completions`) enables you to execute 
 | `agent_name` | `string` | Yes | - | Unique identifier for the agent |
 | `description` | `string` | No | - | Detailed explanation of agent's purpose |
 | `system_prompt` | `string` | No | - | Initial instructions guiding agent behavior |
+| `marketplace_prompt_id` | `string` | No | - | UUID of a marketplace prompt to use as the system prompt |
 | `model_name` | `string` | No | `"gpt-4.1"` | AI model to use (e.g., gpt-4o, gpt-4o-mini, claude-sonnet-4-20250514) |
 | `auto_generate_prompt` | `boolean` | No | `false` | Auto-generate prompts based on task requirements |
 | `max_tokens` | `integer` | No | `8192` | Maximum tokens for agent responses |
@@ -212,6 +213,32 @@ payload = {
     "task": "Write a creative story about time travel"
 }
 ```
+
+### Agent with Marketplace Prompt
+
+You can use prompts from the Swarms marketplace by specifying the `marketplace_prompt_id`. The system will automatically retrieve and use the prompt from the marketplace.
+
+```python
+payload = {
+    "agent_config": {
+        "agent_name": "marketplace-agent",
+        "description": "Agent using a marketplace prompt",
+        "model_name": "gpt-4o-mini",
+        "marketplace_prompt_id": "92a11cf5-ac78-41b7-a4a6-005a92670462",
+        "max_loops": 1,
+        "max_tokens": 8192
+    },
+    "task": "Your task here"
+}
+
+response = requests.post(
+    "https://api.swarms.world/v1/agent/completions",
+    headers={"x-api-key": "your-api-key"},
+    json=payload
+)
+```
+
+**Note**: When `marketplace_prompt_id` is provided, it takes precedence over the `system_prompt` field. You can find marketplace prompts using the [Query Prompts API](/marketplace/prompts-api#query-prompts).
 
 ## Batch Processing
 

--- a/docs/marketplace/prompts-api.mdx
+++ b/docs/marketplace/prompts-api.mdx
@@ -619,3 +619,156 @@ interface Prompt {
   updated_at: string;            // Last update timestamp
 }
 ```
+
+---
+
+## Using Marketplace Prompts with Agents
+
+Once you have a prompt in the marketplace, you can use it with any agent by specifying the `marketplace_prompt_id` in the agent configuration. The Swarms API will automatically retrieve the prompt from the marketplace and apply it to your agent.
+
+### How It Works
+
+1. Query the marketplace to find a suitable prompt using the [Query Prompts](#query-prompts) endpoint
+2. Copy the prompt's `id` from the response
+3. Use the `marketplace_prompt_id` field in your agent configuration
+4. The system automatically retrieves and applies the prompt to your agent
+
+### Example: Using a Marketplace Prompt
+
+<CodeGroup>
+
+```python Python
+import requests
+
+# Step 1: Find a suitable prompt
+query_response = requests.post(
+    "https://swarms.world/api/query-prompts",
+    headers={"Content-Type": "application/json"},
+    json={
+        "search": "technical writing",
+        "category": "content",
+        "limit": 1
+    }
+)
+
+prompts = query_response.json()
+prompt_id = prompts[0]["id"]  # Get the prompt ID
+
+# Step 2: Use the prompt with an agent
+agent_response = requests.post(
+    "https://api.swarms.world/v1/agent/completions",
+    headers={
+        "x-api-key": "YOUR_API_KEY",
+        "Content-Type": "application/json"
+    },
+    json={
+        "agent_config": {
+            "agent_name": "marketplace-agent",
+            "model_name": "gpt-4o-mini",
+            "marketplace_prompt_id": prompt_id,
+            "max_loops": 1
+        },
+        "task": "Write a blog post about Python async/await"
+    }
+)
+
+print(agent_response.json())
+```
+
+```javascript JavaScript
+// Step 1: Find a suitable prompt
+const queryResponse = await fetch('https://swarms.world/api/query-prompts', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    search: 'technical writing',
+    category: 'content',
+    limit: 1
+  })
+});
+
+const prompts = await queryResponse.json();
+const promptId = prompts[0].id;
+
+// Step 2: Use the prompt with an agent
+const agentResponse = await fetch('https://api.swarms.world/v1/agent/completions', {
+  method: 'POST',
+  headers: {
+    'x-api-key': 'YOUR_API_KEY',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    agent_config: {
+      agent_name: 'marketplace-agent',
+      model_name: 'gpt-4o-mini',
+      marketplace_prompt_id: promptId,
+      max_loops: 1
+    },
+    task: 'Write a blog post about Python async/await'
+  })
+});
+
+const result = await agentResponse.json();
+console.log(result);
+```
+
+```bash cURL
+# Step 1: Find a suitable prompt
+PROMPT_ID=$(curl -X POST https://swarms.world/api/query-prompts \
+  -H "Content-Type: application/json" \
+  -d '{"search": "technical writing", "category": "content", "limit": 1}' \
+  | jq -r '.[0].id')
+
+# Step 2: Use the prompt with an agent
+curl -X POST https://api.swarms.world/v1/agent/completions \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"agent_config\": {
+      \"agent_name\": \"marketplace-agent\",
+      \"model_name\": \"gpt-4o-mini\",
+      \"marketplace_prompt_id\": \"$PROMPT_ID\",
+      \"max_loops\": 1
+    },
+    \"task\": \"Write a blog post about Python async/await\"
+  }"
+```
+
+</CodeGroup>
+
+### Direct Usage with Known Prompt ID
+
+If you already know the prompt ID, you can use it directly:
+
+```python
+import requests
+
+response = requests.post(
+    "https://api.swarms.world/v1/agent/completions",
+    headers={
+        "x-api-key": "YOUR_API_KEY",
+        "Content-Type": "application/json"
+    },
+    json={
+        "agent_config": {
+            "agent_name": "marketplace-agent",
+            "model_name": "gpt-4o-mini",
+            "marketplace_prompt_id": "92a11cf5-ac78-41b7-a4a6-005a92670462",
+            "max_loops": 1
+        },
+        "task": "Your task here"
+    }
+)
+
+print(response.json())
+```
+
+### Important Notes
+
+- When `marketplace_prompt_id` is provided, it takes precedence over the `system_prompt` field
+- The prompt is automatically retrieved from the marketplace and applied to the agent
+- You don't need to manually fetch or pass the prompt content
+- Both free and paid marketplace prompts can be used with agents
+- For more details on agent configuration, see the [Agent Completions Reference](/documentation/capabilities/agent)


### PR DESCRIPTION
  # Add Documentation for marketplace_prompt_id Field

  ## Summary

  Added comprehensive documentation for the new `marketplace_prompt_id` field in the AgentSpec schema, which enables agents to use prompts directly from the Swarms marketplace.

  ## What's New

  The `marketplace_prompt_id` field allows users to reference marketplace prompts by UUID instead of manually copying prompt content. When this field is provided, the Swarms API automatically retrieves and applies the specified prompt from the marketplace to the agent.

  ## Changes Made

  ### 1. Agent Completions Reference (`docs/documentation/capabilities/agent.mdx`)
  - Added `marketplace_prompt_id` field to the AgentSpec Object table (line 36)
  - Added new example section "Agent with Marketplace Prompt" (lines 217-241)
  - Included usage notes explaining field precedence over `system_prompt`
  - Added cross-reference to Query Prompts API

  ### 2. Prompts API Documentation (`docs/marketplace/prompts-api.mdx`)
  - Added comprehensive new section "Using Marketplace Prompts with Agents" (lines 625-774)
  - Included step-by-step workflow guide
  - Provided code examples in Python, JavaScript, and cURL
  - Added both query-then-use and direct-use examples
  - Documented important behavioral notes

  ## Key Features Documented

  - Automatic prompt retrieval from marketplace
  - Field takes precedence over `system_prompt`
  - Works seamlessly with existing agent creation flow
  - Supports both free and paid marketplace prompts

  ## Example Usage

  ```python
  {
      "agent_config": {
          "agent_name": "marketplace-agent",
          "model_name": "gpt-4o-mini",
          "marketplace_prompt_id": "92a11cf5-ac78-41b7-a4a6-005a92670462",
          "max_loops": 1
      },
      "task": "Your task here"
  }
